### PR TITLE
Potential performance gain

### DIFF
--- a/5-data-modeling/sql-runner/redshift/sql/web-incremental/01-id-stitching/01-id-stitching.sql
+++ b/5-data-modeling/sql-runner/redshift/sql/web-incremental/01-id-stitching/01-id-stitching.sql
@@ -32,7 +32,7 @@ BEGIN;
     SORTKEY (domain_userid)
   AS (SELECT * FROM derived.id_map);
 
-  DELETE FROM derived.id_map;
+  TRUNCATE derived.id_map;
 
   INSERT INTO snplw_temp.queries (SELECT 'id-stitching', 'backup', GETDATE()); -- (f) track time
 


### PR DESCRIPTION
I tried to measure the impact of this and it looks like when I ran an analyze of 

`DELETE FROM derived.id_map` that it does an O(n) scan to delete all of the records. 

From Redshift [documentation](http://docs.aws.amazon.com/redshift/latest/dg/r_DELETE.html):

> To delete all the rows from a table, TRUNCATE the table. TRUNCATE is much more efficient than DELETE and does not require a VACUUM and ANALYZE. However, be aware that TRUNCATE commits the transaction in which it is run.

I see this this code is in a commit so the purpose of using `DELETE` in this instance is probably to allow for rollback when it fails. Just thought I'd raise a quick question to get your thoughts. 
